### PR TITLE
Make operationName default to nothing in client

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -109,7 +109,7 @@ Depth = 5
 Tokensgraphql(x::String)
 Parse(str::String)
 Queryclient(queryurl::String)
-Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="Bearer 0000", headers::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::String="")
+Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="Bearer 0000", headers::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::Union{String, Nothing}=nothing)
 GraphQLClient(url::String; auth::String="Bearer 0000", headers::Dict=Dict())
 Schema(_schema::String, resolvers::Dict; context=nothing)
 Schema(_schema::Dict, resolvers::Dict; context=nothing)

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -1096,7 +1096,7 @@ function Base.show(io::IO, x::Node)
       catch
         v=true
       end
-      if ((elemento!=nothing) & v)
+      if ((elemento!==nothing) & v)
         if(f == :kind)
           print(io,"Node :: ",elemento)
         elseif(f == :value) | (f == :operation)

--- a/src/Schema.jl
+++ b/src/Schema.jl
@@ -46,7 +46,7 @@ symbol_table = _schema
 
       count_operations = length(document.definitions)
 
-      if (count_operations > 1) && (operationName==nothing)
+      if (count_operations > 1) && (operationName === nothing)
         throw(GraphQLError("{\"data\": null,\"errors\": [{\"message\": \"No operation named.\"}]}"))
       end
 
@@ -55,7 +55,7 @@ symbol_table = _schema
        operation= nothing
        type_operation = " "
 
-       if operationName==nothing
+       if operationName === nothing
           operation= document
           type_operation= document.definitions[1].operation
       else

--- a/src/client.jl
+++ b/src/client.jl
@@ -15,11 +15,14 @@ end
 
 
 """
-    Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="Bearer 0000", headers::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::String="")
+    Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="Bearer 0000", headers::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::Union{String, Nothing}=nothing)
 
   Execute a query with all available parameters
 """
-function Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="Bearer 0000", headers::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::String="")
+function Queryclient(url::String,data::String;
+					 vars::Dict=Dict(),auth::String="Bearer 0000",
+					 headers::Dict=Dict(),getlink::Bool=false,
+					 check::Bool=false,operationName::Union{String, Nothing}=nothing)
 
 	if (check)
 		Validatequery(Parse(data))
@@ -29,7 +32,7 @@ function Queryclient(url::String,data::String; vars::Dict=Dict(),auth::String="B
 		#------------
 		link =url*"?query="*HTTP.escapeuri(data)
 
-		if length(operationName)>0
+		if operationName !== nothing && length(operationName) > 0
            link=link*"&operationName="*operationName
 		end
 
@@ -84,7 +87,7 @@ function GraphQLClient(url::String; auth::String="Bearer 0000", headers::Dict=Di
 		my_auth= auth
 	end
 
-	function Query(data::String; vars::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::String="")
+	function Query(data::String; vars::Dict=Dict(),getlink::Bool=false,check::Bool=false,operationName::Union{String, Nothing}=nothing)
 
 		return Queryclient(my_url,data,vars=vars,auth=my_auth,headers=my_headersextras,getlink=getlink,operationName=operationName,check=check)
 

--- a/src/rules/schema.jl
+++ b/src/rules/schema.jl
@@ -44,7 +44,7 @@ struct extract_operation <:Rule
     found = Dict()
     function enter(node::Node)
       if (active==true) && (node.kind == "OperationDefinition")
-        if node.name != nothing
+        if node.name !== nothing
            if (node.name.value == operationName)
               push!(found, "operation_type" => node.operation, "extracted_operation" => node)
               active=false


### PR DESCRIPTION
I noticed that the example to query github doesn't work without an operationName.
```julia
using Diana
github_endpoint = "https://api.github.com/graphql"
github_user = # GitHub handle
github_token = # GitHub personal token
github_header = Dict("User-Agent" => github_user)
client = GraphQLClient(github_endpoint,
                       auth = "bearer $github_token",
                       headers = github_header)

query = """
        query {
          rateLimit {
            cost
            remaining
            resetAt
          }
          repository(owner: "JuliaLang", name: "Julia") {
            id
          }
        }"""

r = client.Query(query)
r.Info.status == 200 && println(r.Data)
```
This gives a response  `"{\"errors\":[{\"message\":\"No operation named \\\"\\\"\"}]}")`

The current default for operationName `""` results in `"operationName":""` in the JSON payload which will always give an error. Instead, with `nothing` you will get `"operationName":null` which is allowed. I've made `operationName=nothing` the default in the client functions.